### PR TITLE
Remove filtering of column constraint types

### DIFF
--- a/action/command/validate.py
+++ b/action/command/validate.py
@@ -75,6 +75,7 @@ class Validate(Command):
                 "Authorization": f"token {self.github_token}",
             },
             data=json.dumps(data),
+            timeout=30,
         )
         if not r.ok:
             logging.error("Failed to create pull comment: %s", r)

--- a/action/store/postgres.py
+++ b/action/store/postgres.py
@@ -44,7 +44,6 @@ class PostgresStore(Store):
             where 
                 c.table_schema not in ('information_schema', 'pg_catalog') 
                 and c.table_name not in ('migrations')
-                and (tc.constraint_type is null or tc.constraint_type = 'PRIMARY KEY')
             ;"""
         )
 


### PR DESCRIPTION
This previously filtered out constraint types other than null and `PRIMARY KEY`, so columns with `UNIQUE` or `FOREIGN KEY` were incorrectly omitted from the data.json output