### PR TITLE
[minor] allow creation of assumed roles before migrating

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -39,8 +39,6 @@ fi
 
 DOCKER_CLEANUP=""
 
-ROLES_FILE_PATH="$ACTION_PATH/init_roles.sh"
-
 cleanup () {
     echo "Cleaning up..."
     if [[ ! -z "$DOCKER_CLEANUP" ]]; then

--- a/action.sh
+++ b/action.sh
@@ -69,24 +69,13 @@ generate () {
 
             postgres_container=data-dictionary-postgres
 
-            # Overwrite roles file if it exists already
-            echo "#!/bin/bash" > $ROLES_FILE_PATH
-            echo "set -e" >> $ROLES_FILE_PATH
-
-            for ROLE in ${REQUIRED_ROLES}; do
-                echo "psql --username \"$DB_USER\" --dbname \"$DB_NAME\" -c \"CREATE ROLE \\\"$ROLE\\\" LOGIN\"" >> $ROLES_FILE_PATH
-            done
-
-            echo "Roles to be created by roles script: $ROLES_FILE_PATH"
-            cat $ROLES_FILE_PATH
-
             docker run -d \
                 -v $ACTION_PATH/containers/postgres/initdb.sh:/docker-entrypoint-initdb.d/initdb.sh \
-                -v $ROLES_FILE_PATH:/docker-entrypoint-initdb.d/init_roles.sh \
                 -p 5432:5432 \
                 -e POSTGRES_DB=${DB_NAME} \
                 -e POSTGRES_USER=${DB_USER} \
                 -e POSTGRES_PASSWORD=${DB_PASSWORD} \
+                -e REQUIRED_ROLES="${REQUIRED_ROLES}" \
                 --name $postgres_container \
                 postgres:14
 

--- a/action.sh
+++ b/action.sh
@@ -52,15 +52,6 @@ trap cleanup EXIT
 
 prepare () {
     pip3 install -r $ACTION_PATH/requirements.txt
-
-    # Overwrite roles file if it exists already
-    echo "#!/bin/bash" > $ROLES_FILE_PATH
-    echo "set -e" >> $ROLES_FILE_PATH
-
-    for ROLE in ${REQUIRED_ROLES}; do
-        echo echo "psql --username \"$DB_USER\" --dbname \"$DB_NAME\"  CREATE ROLE \"$ROLE\" LOGIN" >> $ROLES_FILE_PATH
-    done
-
 }
 
 generate () {
@@ -77,6 +68,17 @@ generate () {
             pip3 install -r ./requirements-postgres.txt
 
             postgres_container=data-dictionary-postgres
+
+            # Overwrite roles file if it exists already
+            echo "#!/bin/bash" > $ROLES_FILE_PATH
+            echo "set -e" >> $ROLES_FILE_PATH
+
+            for ROLE in ${REQUIRED_ROLES}; do
+                echo "psql --username \"$DB_USER\" --dbname \"$DB_NAME\" -c \"CREATE ROLE \\\"$ROLE\\\" LOGIN\"" >> $ROLES_FILE_PATH
+            done
+
+            echo "Roles to be created by roles script: $ROLES_FILE_PATH"
+            cat $ROLES_FILE_PATH
 
             docker run -d \
                 -v $ACTION_PATH/containers/postgres/initdb.sh:/docker-entrypoint-initdb.d/initdb.sh \

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
     description: "GitHub auth token for pull request comments (NOT for commits)."
     required: false
     default: ${{ github.token }}
+  required-roles:
+    description: "Any user roles which the application expects to exist before migrating. Seprate with whitespace if multiple are required, eg `admin develop`."
+    required: false
 
 runs:
   using: "composite"
@@ -32,5 +35,6 @@ runs:
         STORE_TYPE: ${{ inputs.store-type }}
         TOOL_TYPE: ${{ inputs.tool-type }}
         TOOL_PATH: ${{ inputs.tool-path }}
+        REQUIRED_ROLES: ${{ inputs.required-roles }}
         GITHUB_TOKEN: ${{ inputs.repo-token }}
         GITHUB_PULL: ${{ github.event.pull_request.number }}

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: ${{ github.token }}
   required-roles:
-    description: "Any user roles which the application expects to exist before migrating. Seprate with whitespace if multiple are required, eg `admin develop`."
+    description: "Any user roles which the application expects to exist before migrating. Separate with whitespace if multiple are required, e.g. `admin develop`."
     required: false
 
 runs:

--- a/containers/postgres/initdb.sh
+++ b/containers/postgres/initdb.sh
@@ -4,3 +4,7 @@ set -e
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 EOSQL
+
+for ROLE in ${REQUIRED_ROLES}; do
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -c "CREATE ROLE \"$ROLE\" LOGIN"
+done


### PR DESCRIPTION
In our infra model, services are provided access to specific db roles which are provisioned at db creation. 

In code migrations which provide roles access to specific tables, we want to write the migration assuming the role already exists.

This PR adds an option allowing services to explicitly specify roles that are assumed to exist by migrations, allowing them to pass.