### PR TITLE
update command to install sql-migrate

### DIFF
--- a/containers/golang/Dockerfile
+++ b/containers/golang/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add bash build-base
 
 ARG tool_type=rubenv-sql-migrate
 RUN if [ "$tool_type" = "rubenv-sql-migrate" ]; then \
-    go get -v github.com/rubenv/sql-migrate/...; \
+    go install github.com/rubenv/sql-migrate/...@latest; \
   fi
 
 WORKDIR /


### PR DESCRIPTION
Data dictionary action was updated to use golang 1.20 from 1.17 and no longer supports `go get`

Update go command to fix failing data-dictionary action [as here](https://github.com/mx51/msp-message-service/actions/runs/5328656245/jobs/9653740566?pr=232#step:3:168)