### PR TITLE
[minor] Update config to Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
 For local development, ensure the following are installed:
 
 - Docker
-- Python 3.8+
+- Python 3.10+
 
 The following environment variables are required to be set (e.g. `.env` file):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py310']
 include = '\.pyi?$'
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 ignore_missing_imports = true
 
 [tool.pylint.master]


### PR DESCRIPTION
Update project config and targets to Python 3.10. Since it runs on `ubuntu-latest`, which is currently [`ubuntu-22.04`](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md), it already runs on Python 3.10.6.