### PR TITLE
Fix temporary go-sqlite3 build error

### DIFF
--- a/containers/golang/Dockerfile
+++ b/containers/golang/Dockerfile
@@ -2,6 +2,9 @@ FROM golang:1.21-alpine
 
 RUN apk update && apk add bash build-base
 
+# Temporary fix for https://github.com/mattn/go-sqlite3/pull/1177. We can remove this once rubenv-sql-migrate is updated to use the patched version of go-sqllite3.
+ENV CGO_CFLAGS="-D_LARGEFILE64_SOURCE"
+
 ARG tool_type=rubenv-sql-migrate
 RUN if [ "$tool_type" = "rubenv-sql-migrate" ]; then \
     go install github.com/rubenv/sql-migrate/...@latest; \

--- a/containers/golang/Dockerfile
+++ b/containers/golang/Dockerfile
@@ -4,7 +4,6 @@ RUN apk update && apk add bash build-base
 
 ARG tool_type=rubenv-sql-migrate
 RUN if [ "$tool_type" = "rubenv-sql-migrate" ]; then \
-    # CGO_CFLAGS is a temporary fix for https://github.com/mattn/go-sqlite3/pull/1177.
     CGO_CFLAGS="-D_LARGEFILE64_SOURCE" go install github.com/rubenv/sql-migrate/...@latest; \
   fi
 

--- a/containers/golang/Dockerfile
+++ b/containers/golang/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add bash build-base
 
 ARG tool_type=rubenv-sql-migrate
 RUN if [ "$tool_type" = "rubenv-sql-migrate" ]; then \
-    # CGO_CFLAGS is a temporary fix for https://github.com/mattn/go-sqlite3/pull/1177. We can remove this once rubenv-sql-migrate is updated to use the patched version of go-sqllite3.
+    # CGO_CFLAGS is a temporary fix for https://github.com/mattn/go-sqlite3/pull/1177.
     CGO_CFLAGS="-D_LARGEFILE64_SOURCE" go install github.com/rubenv/sql-migrate/...@latest; \
   fi
 

--- a/containers/golang/Dockerfile
+++ b/containers/golang/Dockerfile
@@ -2,12 +2,12 @@ FROM golang:1.21-alpine
 
 RUN apk update && apk add bash build-base
 
-# Temporary fix for https://github.com/mattn/go-sqlite3/pull/1177. We can remove this once rubenv-sql-migrate is updated to use the patched version of go-sqllite3.
-ENV CGO_CFLAGS="-D_LARGEFILE64_SOURCE"
+
 
 ARG tool_type=rubenv-sql-migrate
 RUN if [ "$tool_type" = "rubenv-sql-migrate" ]; then \
-    go install github.com/rubenv/sql-migrate/...@latest; \
+    # CGO_CFLAGS is a temporary fix for https://github.com/mattn/go-sqlite3/pull/1177. We can remove this once rubenv-sql-migrate is updated to use the patched version of go-sqllite3.
+    CGO_CFLAGS="-D_LARGEFILE64_SOURCE" go install github.com/rubenv/sql-migrate/...@latest; \
   fi
 
 WORKDIR /

--- a/containers/golang/Dockerfile
+++ b/containers/golang/Dockerfile
@@ -2,8 +2,6 @@ FROM golang:1.21-alpine
 
 RUN apk update && apk add bash build-base
 
-
-
 ARG tool_type=rubenv-sql-migrate
 RUN if [ "$tool_type" = "rubenv-sql-migrate" ]; then \
     # CGO_CFLAGS is a temporary fix for https://github.com/mattn/go-sqlite3/pull/1177. We can remove this once rubenv-sql-migrate is updated to use the patched version of go-sqllite3.


### PR DESCRIPTION
- Temporary workaround until https://github.com/rubenv/sql-migrate/pull/259 is merged to update go-sqllite3 to the patched version.