### PR TITLE
Updating golang version to 1.25 in dockerfile

### DIFF
--- a/containers/golang/Dockerfile
+++ b/containers/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine
+FROM golang:1.25-alpine
 
 RUN apk update && apk add bash build-base git
 

--- a/containers/golang/Dockerfile
+++ b/containers/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 RUN apk update && apk add bash build-base git
 


### PR DESCRIPTION
Updating Golang version to 1.25 as github.com/rubenv/sql-migrate@v1.8.1 requires go >= 1.24.0
