### PR TITLE
[notag] chore: update actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/cache@v3
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Updating deprecated actions/checkout@v4 to v6.